### PR TITLE
More general improvements to v2

### DIFF
--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
@@ -74,16 +74,6 @@ public interface Account {
     CompletableFuture<Response<BigDecimal>> retrieveBalance(@NotNull Currency currency);
 
     /**
-     * Gets the starting balance of this {@code Account} for the specified {@link Currency
-     * currency}.
-     *
-     * @param currency the currency for which the starting balance shall be retrieved.
-     * @return the starting balance of this account for the specified currency
-     */
-    @NotNull
-    BigDecimal getStartingBalance(@NotNull Currency currency);
-
-    /**
      * Withdraw an amount from the {@code Account} balance.
      *
      * @param amount    the amount the balance will be reduced by
@@ -296,7 +286,7 @@ public interface Account {
                 .newBuilder()
                 .withCurrency(currency)
                 .withInitiator(initiator)
-                .withTransactionAmount(getStartingBalance(currency))
+                .withTransactionAmount(currency.getStartingBalance(this))
                 .withReason(reason)
                 .withImportance(importance)
                 .withTransactionType(EconomyTransactionType.SET)

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -49,21 +49,21 @@ public interface Currency {
      * Gets the currency's decimal character for the specified {@link Locale locale} to be used for
      * formatting purposes.
      * <p>
-     * The given {@link Locale locale} may be null (unspecified), in this case, the decimal
-     * character of this {@link Currency currency}'s default locale should be returned.
+     * The given {@code locale} may be {@code null} (unspecified), in this case, the decimal
+     * character of this currency's default locale should be returned.
      * <p>
-     * If the decimal character for a given {@link Locale locale} is not available, the decimal
-     * character of this {@link Currency currency}'s default locale should be returned.
+     * If the decimal character for a given {@code Locale} is not available, the decimal
+     * character of this currency's default locale should be returned.
      *
-     * @return decimal character of the given locale, if available (may fallback on a default
-     * locale).
+     * @return decimal character of the given locale, if available (may fall back on a default
+     *         locale).
      * @since v2.0.0
      */
     char getDecimal(@Nullable Locale locale);
 
     /**
-     * Gets a map of each available {@link Currency#getDecimal(Locale) decimal character}, mapped
-     * by the locale it belongs to.
+     * Returns an immutable {@link Map} of each available {@link Currency#getDecimal(Locale)
+     * decimal character}, mapped by the locale it belongs to.
      *
      * @return map of decimal characters against which locale they each belong to
      * @since v2.0.0
@@ -107,7 +107,9 @@ public interface Currency {
     int getPrecision();
 
     /**
-     * Checks if this currency is the primary currency to use of this economy provider.
+     * Checks if this {@code Currency} is the primary currency to use of the
+     * {@link me.lokka30.treasury.api.economy.EconomyProvider economy provider} this {@code
+     * Currency} originated from.
      *
      * @return {@code true} if this currency is the primary currency of this economy provider,
      *         otherwise, {@code} false.
@@ -117,17 +119,16 @@ public interface Currency {
 
     /**
      * Gets the starting balance of the specified {@link Account account} for this particular
-     * {@link Currency currency}.
+     * {@code Currency}.
      * <p>
      * An economy provider may choose to have different starting balances of this
-     * {@link Currency currency} on a per-{@link Account account} basis.
+     * {@code Currency} on a per-{@link Account account} basis.
      *
      * @param account the account for which the starting balance shall be retrieved.
      * @return the starting balance of this currency for the specified account
      * @since v2.0.0
      */
-    @NotNull
-    BigDecimal getStartingBalance(@NotNull Account account);
+    @NotNull BigDecimal getStartingBalance(@NotNull Account account);
 
     /**
      * Get the conversion rate of this {@code Currency}.
@@ -157,9 +158,10 @@ public interface Currency {
         Objects.requireNonNull(currency, "currency");
         Objects.requireNonNull(amount, "amount");
 
-        return amount
-                .multiply(this.getConversionRate())
-                .divide(currency.getConversionRate(), RoundingMode.HALF_UP);
+        return amount.multiply(this.getConversionRate()).divide(
+                currency.getConversionRate(),
+                RoundingMode.HALF_UP
+        );
     }
 
     /**
@@ -178,10 +180,8 @@ public interface Currency {
      *         resulting {@link BigDecimal} that is represented by the specified string .
      * @since v2.0.0
      */
-    @NotNull
-    CompletableFuture<Response<BigDecimal>> parse(
-            @NotNull String formattedAmount,
-            @Nullable Locale locale
+    @NotNull CompletableFuture<Response<BigDecimal>> parse(
+            @NotNull String formattedAmount, @Nullable Locale locale
     );
 
     /**

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import me.lokka30.treasury.api.common.response.Response;
+import me.lokka30.treasury.api.economy.account.Account;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -98,6 +99,19 @@ public interface Currency {
     boolean isPrimary();
 
     /**
+     * Gets the starting balance of the specified {@link Account account} for this particular
+     * {@link Currency currency}.
+     * <p>
+     * An economy provider may choose to have different starting balances of this
+     * {@link Currency currency} on a per-{@link Account account} basis.
+     *
+     * @param account the account for which the starting balance shall be retrieved.
+     * @return the starting balance of this currency for the specified account
+     */
+    @NotNull
+    BigDecimal getStartingBalance(@NotNull Account account);
+
+    /**
      * Get the conversion rate of this {@code Currency}.
      * <p>
      * A conversion rate is a rate of how this currency will be converted to other currencies.
@@ -121,9 +135,7 @@ public interface Currency {
      * @since v1.0.0
      */
     @NotNull
-    default BigDecimal to(
-            @NotNull Currency currency, @NotNull BigDecimal amount
-    ) {
+    default BigDecimal to(@NotNull Currency currency, @NotNull BigDecimal amount) {
         Objects.requireNonNull(currency, "currency");
         Objects.requireNonNull(amount, "amount");
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -89,21 +89,22 @@ public interface Currency {
     int getPrecision();
 
     /**
-     * Checks if this currency is the primary currency to use.
+     * Checks if this currency is the primary currency to use of this economy provider.
      *
-     * @return True if this currency is the primary currency. This method should use a global
-     *         context if multi-world support is not present, otherwise it should use the default world
-     *         for this check.
+     * @return {@code true} if this currency is the primary currency of this economy provider,
+     *         otherwise, {@code} false.
      * @since v1.0.0
      */
     boolean isPrimary();
 
     /**
      * Get the conversion rate of this {@code Currency}.
-     * <p>A conversion rate is a rate of how this currency will be converted to other currencies.
-     * As an example, the conversion rate of BGN and EUR are as following: {@code 0.511292} and
-     * {@code 0.884059}. By the default formula used in {@link #to(Currency, BigDecimal)}, the
-     * conversion of 1 BGN -> EUR will result in {@code 0.51129188} of EUR.
+     * <p>
+     * A conversion rate is a rate of how this currency will be converted to other currencies.
+     * <p>
+     * For example, the conversion rate of BGN and EUR may be {@code 0.511292} and {@code 0.884059},
+     * respectively. By the default formula used in {@link #to(Currency, BigDecimal)}, the
+     * conversion of 1 BGN -> EUR will result in {@code 0.51129188} EUR.
      *
      * @return conversion rate
      * @since 2.0.0

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -68,7 +68,7 @@ public interface Currency {
      * @return map of decimal characters against which locale they each belong to
      * @since v2.0.0
      */
-    Map<Locale, Character> getLocaleDecimalMap();
+    @NotNull Map<Locale, Character> getLocaleDecimalMap();
 
     /**
      * Gets the singular form of the currency's user-friendly display name.

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -73,7 +73,15 @@ public interface Currency {
     @NotNull String getDisplayNamePlural();
 
     /**
-     * Gets the currency's default number of decimal digits when formatting this currency.
+     * Gets the currency's precision of fractional digits when formatting this currency.
+     * <p>
+     * This method concerns precision, not formatting. The economy provider is expected to handle
+     * numbers internally with <i>x</i> fractional digits of precision.
+     * <p>
+     * For instance, if you are using the SQL data type {@code DECIMAL(38, 4)}, you are storing
+     * numbers with a precision of {@code 4} fractional digits.
+     * <p>
+     * It is recommended that you have a precision of three or more fractional digits.
      *
      * @return The currency's default number of decimal digits when formatting this currency.
      * @since v1.0.0

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -50,12 +50,12 @@ public interface Currency {
      * formatting purposes.
      * <p>
      * The given {@link Locale locale} may be null (unspecified), in this case, the decimal
-     * character of this {@link Currency currency}'s preferred locale should be returned.
+     * character of this {@link Currency currency}'s default locale should be returned.
      * <p>
      * If the decimal character for a given {@link Locale locale} is not available, the decimal
-     * character of this {@link Currency currency}'s preferred locale should be returned.
+     * character of this {@link Currency currency}'s default locale should be returned.
      *
-     * @return decimal character of the given locale, if available (may fallback on preferred
+     * @return decimal character of the given locale, if available (may fallback on a default
      * locale).
      * @since v2.0.0
      */
@@ -163,33 +163,45 @@ public interface Currency {
     }
 
     /**
-     * Used to get the BigDecimal representation of an amount represented by a formatted string.
+     * Converts a formatted amount string (i.e., one generated via
+     * {@link Currency#format(BigDecimal, Locale)}) into the BigDecimal value it represents,
+     * according to the specified locale (nullable).
+     * <p>
+     * If a per-locale formatting system is not used by the currency, the parameter can be ignored.
+     * If the specified locale is null, the currency implementation should assume a default.
+     * <p>
      * If the specified string cannot be parsed, a {@link Response} with a suitable
-     * {@link me.lokka30.treasury.api.common.response.FailureReason} shall be returned.
+     * {@link me.lokka30.treasury.api.common.response.FailureReason} is returned.
      *
-     * @param formatted The formatted string to be converted to BigDecimal form.
-     * @return future with {@link Response} which if successful returns the resulting
-     *         {@link BigDecimal} that represents the deformatted amount of the formatted String.
-     * @since v1.0.0
+     * @param formattedAmount formatted amount string to be parsed
+     * @return future containing a {@link Response response} which, if successful, contains the
+     *         resulting {@link BigDecimal} that is represented by the specified string .
+     * @since v2.0.0
      */
     @NotNull
-    CompletableFuture<Response<BigDecimal>> parse(@NotNull String formatted);
+    CompletableFuture<Response<BigDecimal>> parse(
+            @NotNull String formattedAmount,
+            @Nullable Locale locale
+    );
 
     /**
-     * Used to translate an amount to a user readable format with the default precision.
-     * If a per-locale format is not used, simply ignore the parameter.
+     * Translates the given {@link BigDecimal amount} to a human-readable representation as a
+     * formatted string. The formatted string should be determined by the given
+     * {@link Locale locale}.
      *
      * @param amount The amount to format.
      * @param locale The locale to use for formatting the balance. This value may be
-     *               {@code null} if the provider should provide their 'default' Locale.
-     * @return The formatted text.
+     *               {@code null} if the provider should assume a default locale.
+     * @return human-readable representation of the {@link BigDecimal amount} as a formatted string
      * @since v1.0.0
      */
     @NotNull String format(@NotNull BigDecimal amount, @Nullable Locale locale);
 
     /**
      * Used to translate an amount to a user readable format with the specified amount of decimal places.
-     * If a per-locale format is not used, simply ignore the parameter.
+     * <p>
+     * If a per-locale formatting system is not used by the currency, the parameter can be ignored -
+     * likewise with the specified precision value.
      *
      * @param amount    The amount to format.
      * @param locale    The locale to use for formatting the balance. This value may be

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -7,6 +7,7 @@ package me.lokka30.treasury.api.economy.currency;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import me.lokka30.treasury.api.common.response.Response;
@@ -59,6 +60,15 @@ public interface Currency {
      * @since v2.0.0
      */
     char getDecimal(@Nullable Locale locale);
+
+    /**
+     * Gets a map of each available {@link Currency#getDecimal(Locale) decimal character}, mapped
+     * by the locale it belongs to.
+     *
+     * @return map of decimal characters against which locale they each belong to
+     * @since v2.0.0
+     */
+    Map<Locale, Character> getLocaleDecimalMap();
 
     /**
      * Gets the singular form of the currency's user-friendly display name.

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -8,7 +8,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import me.lokka30.treasury.api.common.response.Response;
 import me.lokka30.treasury.api.economy.account.Account;
@@ -46,12 +45,20 @@ public interface Currency {
     @NotNull String getSymbol();
 
     /**
-     * Gets the currency's decimal character to be used for formatting purposes.
+     * Gets the currency's decimal character for the specified {@link Locale locale} to be used for
+     * formatting purposes.
+     * <p>
+     * The given {@link Locale locale} may be null (unspecified), in this case, the decimal
+     * character of this {@link Currency currency}'s preferred locale should be returned.
+     * <p>
+     * If the decimal character for a given {@link Locale locale} is not available, the decimal
+     * character of this {@link Currency currency}'s preferred locale should be returned.
      *
-     * @return The currency's decimal character.
-     * @since v1.0.0
+     * @return decimal character of the given locale, if available (may fallback on preferred
+     * locale).
+     * @since v2.0.0
      */
-    char getDecimal();
+    char getDecimal(@Nullable Locale locale);
 
     /**
      * Gets the singular form of the currency's user-friendly display name.
@@ -107,6 +114,7 @@ public interface Currency {
      *
      * @param account the account for which the starting balance shall be retrieved.
      * @return the starting balance of this currency for the specified account
+     * @since v2.0.0
      */
     @NotNull
     BigDecimal getStartingBalance(@NotNull Account account);
@@ -121,7 +129,7 @@ public interface Currency {
      * conversion of 1 BGN -> EUR will result in {@code 0.51129188} EUR.
      *
      * @return conversion rate
-     * @since 2.0.0
+     * @since v2.0.0
      */
     @NotNull BigDecimal getConversionRate();
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -5,6 +5,7 @@
 package me.lokka30.treasury.api.economy.currency;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
@@ -116,7 +117,10 @@ public interface Currency {
     ) {
         Objects.requireNonNull(currency, "currency");
         Objects.requireNonNull(amount, "amount");
-        return amount.multiply(this.getConversionRate()).divide(currency.getConversionRate());
+
+        return amount
+                .multiply(this.getConversionRate())
+                .divide(currency.getConversionRate(), RoundingMode.HALF_UP);
     }
 
     /**

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
@@ -138,25 +138,21 @@ class CurrenciesMigrator implements Runnable {
             @Override
             @NotNull
             public CompletableFuture<Response<BigDecimal>> parse(
-                    @NotNull String formatted,
-                    @Nullable Locale locale
+                    @NotNull String formatted, @Nullable Locale locale
             ) {
                 return c.parse(formatted, locale);
             }
 
             @Override
             public @NotNull String format(
-                    @NotNull BigDecimal amount,
-                    @Nullable Locale locale
+                    @NotNull BigDecimal amount, @Nullable Locale locale
             ) {
                 return c.format(amount, locale);
             }
 
             @Override
             public @NotNull String format(
-                    @NotNull BigDecimal amount,
-                    @Nullable Locale locale,
-                    final int precision
+                    @NotNull BigDecimal amount, @Nullable Locale locale, final int precision
             ) {
                 return c.format(amount, locale, precision);
             }

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -99,6 +98,11 @@ class CurrenciesMigrator implements Runnable {
             @Override
             public char getDecimal(@Nullable Locale locale) {
                 return c.getDecimal(locale);
+            }
+
+            @Override
+            public @NotNull Map<Locale, Character> getLocaleDecimalMap() {
+                return c.getLocaleDecimalMap();
             }
 
             @Override

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
@@ -137,23 +137,26 @@ class CurrenciesMigrator implements Runnable {
 
             @Override
             @NotNull
-            public CompletableFuture<Response<BigDecimal>> parse(@NotNull String formatted) {
-                return c.parse(formatted);
+            public CompletableFuture<Response<BigDecimal>> parse(
+                    @NotNull String formatted,
+                    @Nullable Locale locale
+            ) {
+                return c.parse(formatted, locale);
             }
 
             @Override
             public @NotNull String format(
-                @NotNull BigDecimal amount,
-                @Nullable Locale locale
+                    @NotNull BigDecimal amount,
+                    @Nullable Locale locale
             ) {
                 return c.format(amount, locale);
             }
 
             @Override
             public @NotNull String format(
-                @NotNull BigDecimal amount,
-                @Nullable Locale locale,
-                final int precision
+                    @NotNull BigDecimal amount,
+                    @Nullable Locale locale,
+                    final int precision
             ) {
                 return c.format(amount, locale, precision);
             }

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/CurrenciesMigrator.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.common.response.Response;
 import me.lokka30.treasury.api.economy.EconomyProvider;
+import me.lokka30.treasury.api.economy.account.Account;
 import me.lokka30.treasury.api.economy.currency.Currency;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -96,8 +97,8 @@ class CurrenciesMigrator implements Runnable {
             }
 
             @Override
-            public char getDecimal() {
-                return c.getDecimal();
+            public char getDecimal(@Nullable Locale locale) {
+                return c.getDecimal(locale);
             }
 
             @Override
@@ -121,6 +122,11 @@ class CurrenciesMigrator implements Runnable {
             }
 
             @Override
+            public @NotNull BigDecimal getStartingBalance(@NotNull final Account account) {
+                return c.getStartingBalance(account);
+            }
+
+            @Override
             public @NotNull BigDecimal getConversionRate() {
                 return c.getConversionRate();
             }
@@ -133,17 +139,17 @@ class CurrenciesMigrator implements Runnable {
 
             @Override
             public @NotNull String format(
-                    @NotNull BigDecimal amount,
-                    @Nullable Locale locale
+                @NotNull BigDecimal amount,
+                @Nullable Locale locale
             ) {
                 return c.format(amount, locale);
             }
 
             @Override
             public @NotNull String format(
-                    @NotNull BigDecimal amount,
-                    @Nullable Locale locale,
-                    final int precision
+                @NotNull BigDecimal amount,
+                @Nullable Locale locale,
+                final int precision
             ) {
                 return c.format(amount, locale, precision);
             }

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
@@ -6,8 +6,10 @@ package me.lokka30.treasury.plugin.core.command.subcommand.economy.migrate;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -57,6 +59,13 @@ class MigrationEconomy implements EconomyProvider {
             @Override
             public char getDecimal(final @Nullable Locale locale) {
                 return '.';
+            }
+
+            @Override
+            public @NotNull Map<Locale, Character> getLocaleDecimalMap() {
+                final Map<Locale, Character> map = new HashMap<>();
+                map.put(Locale.getDefault(), '.');
+                return map;
             }
 
             @Override

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
@@ -100,7 +100,10 @@ class MigrationEconomy implements EconomyProvider {
 
             @Override
             @NotNull
-            public CompletableFuture<Response<BigDecimal>> parse(@NotNull final String formatted) {
+            public CompletableFuture<Response<BigDecimal>> parse(
+                    @NotNull final String formatted,
+                    @Nullable final Locale locale
+            ) {
                 return CompletableFuture.completedFuture(Response.failure(MIGRATION));
             }
 

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
@@ -17,6 +17,7 @@ import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.common.response.FailureReason;
 import me.lokka30.treasury.api.common.response.Response;
 import me.lokka30.treasury.api.economy.EconomyProvider;
+import me.lokka30.treasury.api.economy.account.Account;
 import me.lokka30.treasury.api.economy.account.AccountData;
 import me.lokka30.treasury.api.economy.account.NonPlayerAccount;
 import me.lokka30.treasury.api.economy.account.PlayerAccount;
@@ -35,7 +36,8 @@ import org.jetbrains.annotations.Nullable;
  */
 class MigrationEconomy implements EconomyProvider {
     
-    private static final FailureReason MIGRATION = () -> "The feature is currently not available during migration.";
+    private static final FailureReason MIGRATION = () ->
+            "The feature is currently not available during migration.";
 
     private final @NotNull Currency currency;
     private final @NotNull AccountAccessor accountAccessor;
@@ -53,18 +55,18 @@ class MigrationEconomy implements EconomyProvider {
             }
 
             @Override
-            public char getDecimal() {
-                return 0;
+            public char getDecimal(final @Nullable Locale locale) {
+                return '.';
             }
 
             @Override
             public @NotNull String getDisplayNameSingular() {
-                return "MigrationMoney";
+                return getIdentifier();
             }
 
             @Override
             public @NotNull String getDisplayNamePlural() {
-                return "MigrationMonies";
+                return getIdentifier();
             }
 
             @Override
@@ -75,6 +77,11 @@ class MigrationEconomy implements EconomyProvider {
             @Override
             public boolean isPrimary() {
                 return false;
+            }
+
+            @Override
+            public @NotNull BigDecimal getStartingBalance(@NotNull final Account account) {
+                return BigDecimal.ZERO;
             }
 
             @Override

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
@@ -6,7 +6,7 @@ package me.lokka30.treasury.plugin.core.command.subcommand.economy.migrate;
 
 import java.math.BigDecimal;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -37,15 +37,18 @@ import org.jetbrains.annotations.Nullable;
  * @since v1.0.0
  */
 class MigrationEconomy implements EconomyProvider {
-    
-    private static final FailureReason MIGRATION = () ->
-            "The feature is currently not available during migration.";
+
+    private static final FailureReason MIGRATION = () -> "The feature is currently not available during migration.";
 
     private final @NotNull Currency currency;
     private final @NotNull AccountAccessor accountAccessor;
 
     MigrationEconomy() {
         this.currency = new Currency() {
+
+            private Map<Locale, Character> decimalMap = Collections
+                    .singletonMap(Locale.getDefault(), '.');
+
             @Override
             public @NotNull String getIdentifier() {
                 return "MigrationMoney";
@@ -63,9 +66,7 @@ class MigrationEconomy implements EconomyProvider {
 
             @Override
             public @NotNull Map<Locale, Character> getLocaleDecimalMap() {
-                final Map<Locale, Character> map = new HashMap<>();
-                map.put(Locale.getDefault(), '.');
-                return map;
+                return this.decimalMap;
             }
 
             @Override
@@ -95,14 +96,13 @@ class MigrationEconomy implements EconomyProvider {
 
             @Override
             public @NotNull BigDecimal getConversionRate() {
-                return new BigDecimal(1);
+                return BigDecimal.ONE;
             }
 
             @Override
             @NotNull
             public CompletableFuture<Response<BigDecimal>> parse(
-                    @NotNull final String formatted,
-                    @Nullable final Locale locale
+                    @NotNull final String formatted, @Nullable final Locale locale
             ) {
                 return CompletableFuture.completedFuture(Response.failure(MIGRATION));
             }
@@ -133,8 +133,7 @@ class MigrationEconomy implements EconomyProvider {
                     protected @NotNull CompletableFuture<Response<PlayerAccount>> getOrCreate(
                             @NotNull PlayerAccountCreateContext context
                     ) {
-                        return CompletableFuture.completedFuture(Response.failure(
-                                MIGRATION));
+                        return CompletableFuture.completedFuture(Response.failure(MIGRATION));
                     }
                 };
             }
@@ -146,8 +145,7 @@ class MigrationEconomy implements EconomyProvider {
                     protected @NotNull CompletableFuture<Response<NonPlayerAccount>> getOrCreate(
                             @NotNull NonPlayerAccountCreateContext context
                     ) {
-                        return CompletableFuture.completedFuture(Response.failure(
-                                MIGRATION));
+                        return CompletableFuture.completedFuture(Response.failure(MIGRATION));
                     }
                 };
             }


### PR DESCRIPTION
Aims to patch #248

- [x] `getStartingBalance` moved back to `Currency` - the same method is kept which uses an account context, we were just meant to put it in `Currency` instead of `Account`
- [x] Make `Currency#getDecimal` dependent upon a `Locale`